### PR TITLE
fix: improve npm metadata and CI compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "d360",
   "version": "0.0.0",
-  "description": "",
+  "description": "Document360 official command-line interface (CLI)",
   "main": "index.ts",
   "scripts": {
     "semantic-release": "semantic-release",

--- a/src/api/apidocs/import.ts
+++ b/src/api/apidocs/import.ts
@@ -5,6 +5,7 @@ import { Headers } from "node-fetch";
 import ora from "ora";
 import { error, success, warning } from "../../helper/consoleWrapper";
 import { getCIName } from "../../helper/isCI";
+import { isCI } from "../../helper/isCI";
 import { isURL } from "../../helper/isURL";
 import { ApiReferenceOperationType, ApiReferenceSourceType, ImportCommandOptions } from "../../models";
 import { ApiResponse } from "../../models/api-response";
@@ -12,7 +13,7 @@ import { ImportApiReferenceSummary } from "../../models/import.model";
 import d360APIFetch from "../d360APIFetch";
 
 export default async function importFlow(options: ImportCommandOptions) {
-  const spinner = ora({ text: "Importing.." });
+  const spinner = ora({ text: "Importing..", stream: process.stdout, isEnabled: !isCI() && process.stdout.isTTY });
   spinner.start();
   const formData = getImportRequestFormData(options);
   const requestOptions = {
@@ -61,7 +62,7 @@ function handleImportResponse(response: ApiResponse<ImportApiReferenceSummary>) 
       showServerUnAwailableWarning(true);
     } else if (importWarnings.length > 0 && importErrors.length > 0) {
       error(
-        `Import failed! We found ${importWarnings.length} alert(s) and ${importErrors.length} errors. You can use --force to force import your spec file`
+        `Import failed! We found ${importWarnings.length} alert(s) and ${importErrors.length} errors. You can use --force to force import your spec file`,
       );
       if (isServersAvailable == false) {
         showServerUnAwailableWarning(false);
@@ -82,7 +83,7 @@ function handleImportResponse(response: ApiResponse<ImportApiReferenceSummary>) 
 function showServerUnAwailableWarning(withForceInfo: boolean) {
   if (withForceInfo) {
     warning(
-      "You may not be able to use try-it feature. Looks like server variables aren’t defined in your OpenAPI Specification file. You can use --force to force import your spec file"
+      "You may not be able to use try-it feature. Looks like server variables aren’t defined in your OpenAPI Specification file. You can use --force to force import your spec file",
     );
   } else {
     warning("You may not be able to use try-it feature. Looks like server variables aren't defined in your OpenAPI Specification file.");

--- a/src/api/apidocs/resync.ts
+++ b/src/api/apidocs/resync.ts
@@ -2,7 +2,7 @@ import FormData from "form-data";
 import fs from "fs";
 import { Headers } from "node-fetch";
 import ora from "ora";
-import { getCIName } from "../../helper/isCI";
+import { getCIName, isCI } from "../../helper/isCI";
 import { isURL } from "../../helper/isURL";
 import { ApiReferenceOperationType, ApiReferenceSourceType, ResyncCommandOptions } from "../../models";
 import d360APIFetch from "../d360APIFetch";
@@ -11,7 +11,7 @@ import { ImportApiReferenceSummary } from "../../models/import.model";
 import { error, success, warning } from "../../helper/consoleWrapper";
 
 export default async function resyncFlow(options: ResyncCommandOptions) {
-  const spinner = ora({ text: "Resyncing.." });
+  const spinner = ora({ text: "Resyncing..", stream: process.stdout, isEnabled: !isCI() && process.stdout.isTTY });
   spinner.start();
   const formData = getResyncRequestFormData(options);
   const requestOptions = {
@@ -59,7 +59,7 @@ function handleResyncResponse(response: ApiResponse<ImportApiReferenceSummary>) 
       showServerUnAwailableWarning(true);
     } else if (importWarnings.length > 0 && importErrors.length > 0) {
       error(
-        `Resync failed! We found ${importWarnings.length} alert(s) and ${importErrors.length} errors. You can use --force to force import your spec file`
+        `Resync failed! We found ${importWarnings.length} alert(s) and ${importErrors.length} errors. You can use --force to force import your spec file`,
       );
       if (isServersAvailable == false) {
         showServerUnAwailableWarning(false);
@@ -80,7 +80,7 @@ function handleResyncResponse(response: ApiResponse<ImportApiReferenceSummary>) 
 function showServerUnAwailableWarning(withForceInfo: boolean) {
   if (withForceInfo) {
     warning(
-      "You may not be able to use try-it feature. Looks like server variables aren’t defined in your OpenAPI Specification file. You can use --force to force import your spec file"
+      "You may not be able to use try-it feature. Looks like server variables aren’t defined in your OpenAPI Specification file. You can use --force to force import your spec file",
     );
   } else {
     warning("You may not be able to use try-it feature. Looks like server variables aren't defined in your OpenAPI Specification file.");

--- a/src/api/apidocs/validate.ts
+++ b/src/api/apidocs/validate.ts
@@ -4,6 +4,7 @@ import fs from "fs";
 import { Headers } from "node-fetch";
 import ora from "ora";
 import { error, heading, success, warning } from "../../helper/consoleWrapper";
+import { isCI } from "../../helper/isCI";
 import { isURL } from "../../helper/isURL";
 import { ValidateCommandOptions } from "../../models";
 import { ApiResponse } from "../../models/api-response";
@@ -11,7 +12,7 @@ import { ImportApiReferenceSummary } from "../../models/import.model";
 import d360APIFetch from "../d360APIFetch";
 
 export default async function validateFlow(options: ValidateCommandOptions) {
-  const spinner = ora({ text: "Validating.." });
+  const spinner = ora({ text: "Validating..", stream: process.stdout, isEnabled: !isCI() && process.stdout.isTTY });
   spinner.start();
   const formData = getImportRequestFormData(options);
   const requestOptions = {

--- a/src/api/initOas.ts
+++ b/src/api/initOas.ts
@@ -1,29 +1,31 @@
+import ora from "ora";
+import { isCI } from "../helper/isCI";
+import readDirectory from "../helper/readDirectory";
+import terminalWrapper from "../helper/terminalWrapper";
 
-import ora from 'ora';
-import { isCI } from '../helper/isCI';
-import readDirectory from '../helper/readDirectory';
-import terminalWrapper from '../helper/terminalWrapper';
+export default async function findOasFilesInCurrentDirectory() {
+  const isFindingFiles = ora({
+    text: "Looking for json/yaml files..",
+    stream: process.stdout,
+    isEnabled: !isCI() && process.stdout.isTTY,
+  }).start();
 
-export default async function findOasFilesInCurrentDirectory(
-) {
-    const isFindingFiles = ora({ text: 'Looking for json/yaml files..' }).start();
-
-    const allFilesFromDirectory = await readDirectory(".");
-    const specFiles = allFilesFromDirectory.filter(file => file.endsWith(".json") || file.endsWith(".yaml"));
-    if (specFiles.length == 0)
-        throw new Error("No spec files found in the current directory. Please use --path to mention the file path/ URL of your OAS Spec file.")
-    isFindingFiles.stop();
-    if (!isCI()) {
-        const selectedFile = await terminalWrapper({
-            name: 'file',
-            message: 'Choose any one of the spec files listed below',
-            type: 'select',
-            choices: specFiles.map(file => ({
-                title: file,
-                value: file,
-            }))
-        });
-        return selectedFile.file;
-    }
-    return specFiles[0];
+  const allFilesFromDirectory = await readDirectory(".");
+  const specFiles = allFilesFromDirectory.filter((file) => file.endsWith(".json") || file.endsWith(".yaml"));
+  if (specFiles.length == 0)
+    throw new Error("No spec files found in the current directory. Please use --path to mention the file path/ URL of your OAS Spec file.");
+  isFindingFiles.stop();
+  if (!isCI()) {
+    const selectedFile = await terminalWrapper({
+      name: "file",
+      message: "Choose any one of the spec files listed below",
+      type: "select",
+      choices: specFiles.map((file) => ({
+        title: file,
+        value: file,
+      })),
+    });
+    return selectedFile.file;
+  }
+  return specFiles[0];
 }


### PR DESCRIPTION
Set plain-text package description to prevent HTML rendering in npm search. Configure ora spinners to disable in CI environments and non-TTY contexts.